### PR TITLE
V1.1.2

### DIFF
--- a/pacs/mdrun/Cycle.py
+++ b/pacs/mdrun/Cycle.py
@@ -148,11 +148,21 @@ class Cycle:
         fn = f"{self.settings.each_cycle(_cycle=self.cycle)}/summary/progress.log"
         if not Path(fn).exists():
             return True
+        
+        export_needed = True
+        rmmol_needed = self.settings.rmmol
+        rmfile_needed = self.settings.rmfile
+
         with open(fn, "r") as f:
-            a = f.readlines()
-            if len(a) == 0:
-                return True
-            return "export to" not in a[-1]
+            for line in f:
+                if "export to" in line:
+                    export_needed = False
+                if "reduced" in line:
+                    rmmol_needed = False
+                if "rmfile" in line:
+                    rmfile_needed = False
+
+        return any([export_needed, rmmol_needed, rmfile_needed])
 
     # def genrepresent(self) -> None:
     #     genrepresent.genrepresent(self.settings)

--- a/pacs/mdrun/Cycle.py
+++ b/pacs/mdrun/Cycle.py
@@ -148,7 +148,7 @@ class Cycle:
         fn = f"{self.settings.each_cycle(_cycle=self.cycle)}/summary/progress.log"
         if not Path(fn).exists():
             return True
-        
+
         export_needed = True
         rmmol_needed = self.settings.rmmol
         rmfile_needed = self.settings.rmfile

--- a/pacs/mdrun/Cycle.py
+++ b/pacs/mdrun/Cycle.py
@@ -149,9 +149,9 @@ class Cycle:
         if not Path(fn).exists():
             return True
 
-        export_needed = True
-        rmmol_needed = self.settings.rmmol
-        rmfile_needed = self.settings.rmfile
+        export_needed: bool = True
+        rmmol_needed : bool = self.settings.rmmol
+        rmfile_needed: bool = self.settings.rmfile
 
         with open(fn, "r") as f:
             for line in f:

--- a/pacs/mdrun/Cycle.py
+++ b/pacs/mdrun/Cycle.py
@@ -150,7 +150,7 @@ class Cycle:
             return True
 
         export_needed: bool = True
-        rmmol_needed : bool = self.settings.rmmol
+        rmmol_needed: bool = self.settings.rmmol
         rmfile_needed: bool = self.settings.rmfile
 
         with open(fn, "r") as f:

--- a/pacs/utils/rmfile.py
+++ b/pacs/utils/rmfile.py
@@ -2,7 +2,7 @@ import subprocess
 from pathlib import Path
 
 from pacs.models.settings import MDsettings
-from pacs.utils.logger import generate_logger
+from pacs.utils.logger import close_logger, generate_logger
 
 LOGGER = generate_logger(__name__)
 
@@ -101,11 +101,13 @@ def rmfile(settings: MDsettings, cycle: int) -> None:
     LOGGER.info(f"rmfile completed successfully in cycle{cycle:03}")
     record_finished(settings, cycle)
 
+
 def record_finished(settings: MDsettings, cycle: int) -> None:
     dir = settings.each_cycle(_cycle=cycle)
-    logger = generate_logger(f"{cycle}", f"{dir}/summary/progress.log")
+    logger = generate_logger(f"{cycle}_rmfile", f"{dir}/summary/progress.log")
     logger.info(f"rmfile completed successfully in cycle{cycle:03}")
     close_logger(logger)
+
 
 def rmfile_all(settings: MDsettings) -> None:
     max_cycle = detect_n_cycle(settings)

--- a/pacs/utils/rmfile.py
+++ b/pacs/utils/rmfile.py
@@ -99,7 +99,13 @@ def rmfile(settings: MDsettings, cycle: int) -> None:
             continue
 
     LOGGER.info(f"rmfile completed successfully in cycle{cycle:03}")
+    record_finished(settings, cycle)
 
+def record_finished(settings: MDsettings, cycle: int) -> None:
+    dir = settings.each_cycle(_cycle=cycle)
+    logger = generate_logger(f"{cycle}", f"{dir}/summary/progress.log")
+    logger.info(f"rmfile completed successfully in cycle{cycle:03}")
+    close_logger(logger)
 
 def rmfile_all(settings: MDsettings) -> None:
     max_cycle = detect_n_cycle(settings)

--- a/pacs/utils/rmfile.py
+++ b/pacs/utils/rmfile.py
@@ -98,7 +98,7 @@ def rmfile(settings: MDsettings, cycle: int) -> None:
 
             continue
 
-    LOGGER.info(f"rmfile completed successfully in cycle{cycle:03}")
+    # LOGGER.info(f"rmfile completed successfully in cycle{cycle:03}")
     record_finished(settings, cycle)
 
 

--- a/pacs/utils/rmmol.py
+++ b/pacs/utils/rmmol.py
@@ -171,6 +171,7 @@ def rmmol(settings: MDsettings, cycle: int, last_cycle: bool) -> None:
             p.close()
 
     LOGGER.info(f"trajectory files in cycle{cycle:03} have been reduced")
+    record_finished(settings, cycle)
 
 
 def rmmol_replica_mdtraj(
@@ -291,12 +292,19 @@ def rmmol_log_add_info(settings: MDsettings) -> None:
         exit(1)
 
 
+def record_finished(settings: MDsettings, cycle: int) -> None:
+    dir = settings.each_cycle(_cycle=cycle)
+    logger = generate_logger(f"{cycle}", f"{dir}/summary/progress.log")
+    logger.info(f"trajectory files in cycle{cycle:03} have been reduced")
+    close_logger(logger)
+
+
 def rmmol_log_add_info_gmx(settings: MDsettings) -> None:
-    LOGGER.info("prd.tpr files are probably no longer needed")
-    LOGGER.info("it is recommended to remove prd.tpr files to save disk space")
+    LOGGER.info("The 'prd.tpr' files are probably no longer needed.")
+    LOGGER.info("It is recommended to remove 'prd.tpr' files to save disk space.")
     LOGGER.info(
-        "you can manually regenerate the prd.tpr files from input.gro files \
-        even if you need them later"
+        "If needed later, you can manually regenerate the 'prd.tpr' files from "
+        "the 'input.gro' files."
     )
 
 

--- a/pacs/utils/rmmol.py
+++ b/pacs/utils/rmmol.py
@@ -170,7 +170,7 @@ def rmmol(settings: MDsettings, cycle: int, last_cycle: bool) -> None:
         for p in processes:
             p.close()
 
-    LOGGER.info(f"trajectory files in cycle{cycle:03} have been reduced")
+    # LOGGER.info(f"trajectory files in cycle{cycle:03} have been reduced")
     record_finished(settings, cycle)
 
 

--- a/pacs/utils/rmmol.py
+++ b/pacs/utils/rmmol.py
@@ -3,7 +3,7 @@ import subprocess
 from pathlib import Path
 
 from pacs.models.settings import MDsettings
-from pacs.utils.logger import generate_logger
+from pacs.utils.logger import close_logger, generate_logger
 
 LOGGER = generate_logger(__name__)
 
@@ -294,7 +294,7 @@ def rmmol_log_add_info(settings: MDsettings) -> None:
 
 def record_finished(settings: MDsettings, cycle: int) -> None:
     dir = settings.each_cycle(_cycle=cycle)
-    logger = generate_logger(f"{cycle}", f"{dir}/summary/progress.log")
+    logger = generate_logger(f"{cycle}_rmmol", f"{dir}/summary/progress.log")
     logger.info(f"trajectory files in cycle{cycle:03} have been reduced")
     close_logger(logger)
 


### PR DESCRIPTION
If the PaCS-MD job is ceased during `rmmol` or `rmfile`, `rmmol` and `rmfile` were skipped again for that cycle even if restarted.
Treated with that problem
https://github.com/Kitaolab/PaCS-Toolkit/issues/6#issue-2637148103
Fixes #6 