### PR TITLE
fix: Fix the result disorder caused by multiprocessing queue.

### DIFF
--- a/pacs/mdrun/analyzer/a_d.py
+++ b/pacs/mdrun/analyzer/a_d.py
@@ -30,7 +30,7 @@ class A_D(SuperAnalyzer):
             ret = self.cal_by_cpptraj(settings, cycle, replica)
         else:
             raise NotImplementedError
-        queue.put(ret)
+        queue.put((replica, ret))
         return ret
 
     def ranking(self, settings: MDsettings, CVs: List[Snapshot]) -> List[Snapshot]:

--- a/pacs/mdrun/analyzer/association.py
+++ b/pacs/mdrun/analyzer/association.py
@@ -26,7 +26,7 @@ class Association(SuperAnalyzer):
             ret = self.cal_by_cpptraj(settings, cycle, replica)
         else:
             raise NotImplementedError
-        queue.put(ret)
+        queue.put((replica, ret))
         return ret
 
     def ranking(self, settings: MDsettings, CVs: List[Snapshot]) -> List[Snapshot]:

--- a/pacs/mdrun/analyzer/dissociation.py
+++ b/pacs/mdrun/analyzer/dissociation.py
@@ -34,7 +34,7 @@ class Dissociation(SuperAnalyzer):
             ret = self.cal_by_cpptraj(settings, cycle, replica)
         else:
             raise NotImplementedError
-        queue.put(ret)
+        queue.put((replica, ret))
         return ret
 
     def ranking(self, settings: MDsettings, CVs: List[Snapshot]) -> List[Snapshot]:

--- a/pacs/mdrun/analyzer/ee.py
+++ b/pacs/mdrun/analyzer/ee.py
@@ -36,7 +36,7 @@ class EdgeExpansion(SuperAnalyzer):
             ret = self.cal_by_cpptraj(settings, cycle, replica)
         else:
             raise NotImplementedError
-        queue.put(ret)
+        queue.put((replica, ret))
         return ret
 
     def ranking(self, settings: MDsettings, CVs: List[Snapshot]) -> List[Snapshot]:

--- a/pacs/mdrun/analyzer/rmsd.py
+++ b/pacs/mdrun/analyzer/rmsd.py
@@ -29,7 +29,7 @@ class RMSD(SuperAnalyzer):
             ret = self.cal_by_cpptraj(settings, cycle, replica)
         else:
             raise NotImplementedError
-        queue.put(ret)
+        queue.put((replica, ret))
         return ret
 
     def ranking(self, settings: MDsettings, CVs: List[Snapshot]) -> List[Snapshot]:

--- a/pacs/mdrun/analyzer/superAnalyzer.py
+++ b/pacs/mdrun/analyzer/superAnalyzer.py
@@ -18,7 +18,7 @@ class SuperAnalyzer(metaclass=ABCMeta):
     CVs: List[float] = None
 
     @abstractmethod
-    def calculate_cv(self, settings: MDsettings, cycle: int) -> List[float]:
+    def calculate_cv(self, settings: MDsettings, cycle: int, replica: int, queue: mp.Queue) -> List[float]:
         pass
 
     @abstractmethod
@@ -85,7 +85,7 @@ class SuperAnalyzer(metaclass=ABCMeta):
 
             tmp = []
             for _ in range(len(job_list)):
-                cv_arr.append(queue.get())
+                tmp.append(queue.get())
             
             tmp.sort(key=lambda x: x[0])
 

--- a/pacs/mdrun/analyzer/superAnalyzer.py
+++ b/pacs/mdrun/analyzer/superAnalyzer.py
@@ -83,8 +83,14 @@ class SuperAnalyzer(metaclass=ABCMeta):
                 job_list.append(p)
                 p.start()
 
+            tmp = []
             for _ in range(len(job_list)):
                 cv_arr.append(queue.get())
+            
+            tmp.sort(key=lambda x: x[0])
+
+            for replica, ret in tmp:
+                cv_arr.append(ret)
 
             for proc in job_list:
                 proc.join()

--- a/pacs/mdrun/analyzer/target.py
+++ b/pacs/mdrun/analyzer/target.py
@@ -28,7 +28,7 @@ class Target(SuperAnalyzer):
             ret = self.cal_by_cpptraj(settings, cycle, replica)
         else:
             raise NotImplementedError
-        queue.put(ret)
+        queue.put((replica, ret))
         return ret
 
     def ranking(self, settings: MDsettings, CVs: List[Snapshot]) -> List[Snapshot]:


### PR DESCRIPTION
# Fix misordered results caused by multiprocessing queue

## Background
When running analyzers in parallel, results were collected from a `multiprocessing.Queue`.  
However, `Queue.get()` retrieves items in the order they *arrive*, not in the order tasks were *submitted*.  
This caused inconsistent or misordered results when multiple worker processes finished at different speeds.

## What was happening
- Each analyzer task was submitted with an implicit index  
- Worker processes may complete at different times  
- Results were pushed into the queue in a non‑deterministic order  
- Misorder was found in cv.log that replica's CVs do not have the correct label

This led to incorrect or unstable output in several analyzer modules.

## What this PR does
- Introduces **explicit task indexing**
- Ensures each worker returns `(task_id, result)`
- Collects results into a list and **sorts by task_id** before further processing
- Guarantees deterministic ordering regardless of process execution timing
- Applies consistent fixes across:
  - `a_d.py`
  - `association.py`
  - `dissociation.py`
  - `ee.py`
  - `rmsd.py`
  - `superAnalyzer.py`
  - `target.py`

## Testing
- Inserted random `time.sleep()` calls inside `calculate_cv()` to simulate unpredictable worker timing  
- Under the old implementation, this reliably reproduced misordered results due to nondeterministic queue retrieval  
- With the fix applied, results remain correctly ordered even under randomized delays  
- Verified stable output across multiple runs  
- No changes to public API or user‑facing behavior  
